### PR TITLE
Only init once

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -23,6 +23,12 @@ var objectAssign = require('object-assign');
 var RpioRtttlPiezo = function () {};
 
 
+// Initiate GPIO output
+rpio.init({
+	gpiomem: false
+});
+
+
 /**
  * play(opts)
  * Begin playback on specified PWM pin with desired options
@@ -46,10 +52,6 @@ RpioRtttlPiezo.prototype.play = function(opts) {
 	// Parse RTTTL to playable notes
 	opts.tune = rtttlParse.parse(opts.rtttl);
 
-	// Initiate GPIO output
-	rpio.init({
-		gpiomem: false
-	});
 	rpio.open(opts.pwmOutputPin, rpio.PWM);
 	rpio.pwmSetClockDivider(opts.pwmClockDivider);
 


### PR DESCRIPTION
Hi, first pull request hope I've done this correctly!

Calling rpio.init() more than once would eventually lead to a crash with the following error:

`bcm2835_init: gpio mmap failed: Cannot allocate memory`

This seems to prevent that 😄